### PR TITLE
Return BaseClaim if custom Claim not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ boolean isExpired = jwt.isExpired(10); // 10 seconds leeway
 
 ### Private Claims
 
-Additional Claims defined in the token can be obtained by calling `getClaim` and passing the Claim name. If the claim can't be found, null will be returned.
+Additional Claims defined in the token can be obtained by calling `getClaim` and passing the Claim name. If the claim can't be found, a BaseClaim will be returned. BaseClaim will return null on every method call except for the `asList` and `asArray`.
 
 ```java
 Claim claim = jwt.getClaim("isAdmin");

--- a/lib/src/main/java/com/auth0/android/jwt/BaseClaim.java
+++ b/lib/src/main/java/com/auth0/android/jwt/BaseClaim.java
@@ -1,0 +1,56 @@
+package com.auth0.android.jwt;
+
+
+import android.support.annotation.Nullable;
+
+import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The BaseClaim class is a Claim implementation that returns null when any of it's methods it's called.
+ */
+class BaseClaim implements Claim {
+
+    @Nullable
+    @Override
+    public Boolean asBoolean() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Integer asInt() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Double asDouble() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String asString() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Date asDate() {
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T[] asArray(Class<T> tClazz) throws DecodeException {
+        return (T[]) Array.newInstance(tClazz, 0);
+    }
+
+    @Override
+    public <T> List<T> asList(Class<T> tClazz) throws DecodeException {
+        return Collections.emptyList();
+    }
+}

--- a/lib/src/main/java/com/auth0/android/jwt/Claim.java
+++ b/lib/src/main/java/com/auth0/android/jwt/Claim.java
@@ -1,29 +1,14 @@
 package com.auth0.android.jwt;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonSyntaxException;
-
-import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 /**
- * A Claim is a value contained inside the JWT Payload.
+ * The Claim class holds the value in a generic way so that it can be recovered in many representations.
  */
-@SuppressWarnings("WeakerAccess")
-public class Claim {
-
-    private final JsonElement value;
-
-    Claim(@NonNull JsonElement value) {
-        this.value = value;
-    }
+public interface Claim {
 
 
     /**
@@ -33,12 +18,7 @@ public class Claim {
      * @return the value as a Boolean or null.
      */
     @Nullable
-    public Boolean asBoolean() {
-        if (!value.isJsonPrimitive()) {
-            return null;
-        }
-        return value.getAsBoolean();
-    }
+    Boolean asBoolean();
 
     /**
      * Get this Claim as an Integer.
@@ -47,12 +27,7 @@ public class Claim {
      * @return the value as an Integer or null.
      */
     @Nullable
-    public Integer asInt() {
-        if (!value.isJsonPrimitive()) {
-            return null;
-        }
-        return value.getAsInt();
-    }
+    Integer asInt();
 
     /**
      * Get this Claim as a Double.
@@ -61,12 +36,7 @@ public class Claim {
      * @return the value as a Double or null.
      */
     @Nullable
-    public Double asDouble() {
-        if (!value.isJsonPrimitive()) {
-            return null;
-        }
-        return value.getAsDouble();
-    }
+    Double asDouble();
 
     /**
      * Get this Claim as a String.
@@ -75,12 +45,7 @@ public class Claim {
      * @return the value as a String or null.
      */
     @Nullable
-    public String asString() {
-        if (!value.isJsonPrimitive()) {
-            return null;
-        }
-        return value.getAsString();
-    }
+    String asString();
 
     /**
      * Get this Claim as a Date.
@@ -89,13 +54,7 @@ public class Claim {
      * @return the value as a Date or null.
      */
     @Nullable
-    public Date asDate() {
-        if (!value.isJsonPrimitive()) {
-            return null;
-        }
-        long ms = Long.parseLong(value.getAsString()) * 1000;
-        return new Date(ms);
-    }
+    Date asDate();
 
     /**
      * Get this Claim as an Array of type T.
@@ -104,23 +63,7 @@ public class Claim {
      * @return the value as an Array or an empty Array.
      * @throws DecodeException if the values inside the Array can't be converted to a class T.
      */
-    @SuppressWarnings("unchecked")
-    public <T> T[] asArray(Class<T> tClazz) throws DecodeException {
-        try {
-            if (!value.isJsonArray() || value.isJsonNull()) {
-                return (T[]) Array.newInstance(tClazz, 0);
-            }
-            Gson gson = new Gson();
-            JsonArray jsonArr = value.getAsJsonArray();
-            T[] arr = (T[]) Array.newInstance(tClazz, jsonArr.size());
-            for (int i = 0; i < jsonArr.size(); i++) {
-                arr[i] = gson.fromJson(jsonArr.get(i), tClazz);
-            }
-            return arr;
-        } catch (JsonSyntaxException e) {
-            throw new DecodeException("Failed to decode claim as array", e);
-        }
-    }
+    <T> T[] asArray(Class<T> tClazz) throws DecodeException;
 
     /**
      * Get this Claim as a List of type T.
@@ -129,20 +72,5 @@ public class Claim {
      * @return the value as a List or an empty List.
      * @throws DecodeException if the values inside the List can't be converted to a class T.
      */
-    public <T> List<T> asList(Class<T> tClazz) throws DecodeException {
-        try {
-            if (!value.isJsonArray() || value.isJsonNull()) {
-                return new ArrayList<>();
-            }
-            Gson gson = new Gson();
-            JsonArray jsonArr = value.getAsJsonArray();
-            List<T> list = new ArrayList<>();
-            for (int i = 0; i < jsonArr.size(); i++) {
-                list.add(gson.fromJson(jsonArr.get(i), tClazz));
-            }
-            return list;
-        } catch (JsonSyntaxException e) {
-            throw new DecodeException("Failed to decode claim as list", e);
-        }
-    }
+    <T> List<T> asList(Class<T> tClazz) throws DecodeException;
 }

--- a/lib/src/main/java/com/auth0/android/jwt/ClaimImpl.java
+++ b/lib/src/main/java/com/auth0/android/jwt/ClaimImpl.java
@@ -1,0 +1,110 @@
+package com.auth0.android.jwt;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The ClaimImpl class implements the Claim interface.
+ */
+@SuppressWarnings("WeakerAccess")
+class ClaimImpl extends BaseClaim {
+
+    private final JsonElement value;
+
+    ClaimImpl(@NonNull JsonElement value) {
+        this.value = value;
+    }
+
+    @Override
+    @Nullable
+    public Boolean asBoolean() {
+        if (!value.isJsonPrimitive()) {
+            return null;
+        }
+        return value.getAsBoolean();
+    }
+
+    @Override
+    @Nullable
+    public Integer asInt() {
+        if (!value.isJsonPrimitive()) {
+            return null;
+        }
+        return value.getAsInt();
+    }
+
+    @Override
+    @Nullable
+    public Double asDouble() {
+        if (!value.isJsonPrimitive()) {
+            return null;
+        }
+        return value.getAsDouble();
+    }
+
+    @Override
+    @Nullable
+    public String asString() {
+        if (!value.isJsonPrimitive()) {
+            return null;
+        }
+        return value.getAsString();
+    }
+
+    @Override
+    @Nullable
+    public Date asDate() {
+        if (!value.isJsonPrimitive()) {
+            return null;
+        }
+        long ms = Long.parseLong(value.getAsString()) * 1000;
+        return new Date(ms);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T[] asArray(Class<T> tClazz) throws DecodeException {
+        try {
+            if (!value.isJsonArray() || value.isJsonNull()) {
+                return (T[]) Array.newInstance(tClazz, 0);
+            }
+            Gson gson = new Gson();
+            JsonArray jsonArr = value.getAsJsonArray();
+            T[] arr = (T[]) Array.newInstance(tClazz, jsonArr.size());
+            for (int i = 0; i < jsonArr.size(); i++) {
+                arr[i] = gson.fromJson(jsonArr.get(i), tClazz);
+            }
+            return arr;
+        } catch (JsonSyntaxException e) {
+            throw new DecodeException("Failed to decode claim as array", e);
+        }
+    }
+
+    @Override
+    public <T> List<T> asList(Class<T> tClazz) throws DecodeException {
+        try {
+            if (!value.isJsonArray() || value.isJsonNull()) {
+                return new ArrayList<>();
+            }
+            Gson gson = new Gson();
+            JsonArray jsonArr = value.getAsJsonArray();
+            List<T> list = new ArrayList<>();
+            for (int i = 0; i < jsonArr.size(); i++) {
+                list.add(gson.fromJson(jsonArr.get(i), tClazz));
+            }
+            return list;
+        } catch (JsonSyntaxException e) {
+            throw new DecodeException("Failed to decode claim as list", e);
+        }
+    }
+}

--- a/lib/src/main/java/com/auth0/android/jwt/DecodeException.java
+++ b/lib/src/main/java/com/auth0/android/jwt/DecodeException.java
@@ -2,11 +2,11 @@ package com.auth0.android.jwt;
 
 public class DecodeException extends RuntimeException {
 
-    public DecodeException(String message) {
+    DecodeException(String message) {
         super(message);
     }
 
-    public DecodeException(String message, Throwable cause) {
+    DecodeException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/lib/src/main/java/com/auth0/android/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/android/jwt/JWT.java
@@ -132,14 +132,14 @@ public class JWT implements Parcelable {
     }
 
     /**
-     * Get a Private Claim given it's name. If the Claim wasn't specified in the JWT payload, null will be returned.
+     * Get a Private Claim given it's name. If the Claim wasn't specified in the JWT payload, a BaseClaim will be returned.
      *
      * @param name the name of the Claim to retrieve.
-     * @return the Claim if found or null.
+     * @return a valid Claim.
      */
     @Nullable
     public Claim getClaim(@NonNull String name) {
-        return payload.extra.get(name);
+        return payload.extra.containsKey(name) ? payload.extra.get(name) : new BaseClaim();
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/jwt/JWTDeserializer.java
+++ b/lib/src/main/java/com/auth0/android/jwt/JWTDeserializer.java
@@ -36,7 +36,7 @@ class JWTDeserializer implements JsonDeserializer<JWTPayload> {
         //Private Claims
         Map<String, Claim> extra = new HashMap<>();
         for (Map.Entry<String, JsonElement> e : object.entrySet()) {
-            extra.put(e.getKey(), new Claim(e.getValue()));
+            extra.put(e.getKey(), new ClaimImpl(e.getValue()));
         }
 
         return new JWTPayload(iss, sub, exp, nbf, iat, jti, aud, extra);

--- a/lib/src/test/java/com/auth0/android/jwt/BaseClaimTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/BaseClaimTest.java
@@ -1,0 +1,59 @@
+package com.auth0.android.jwt;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.collection.IsArrayWithSize.emptyArray;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class BaseClaimTest {
+
+    private BaseClaim claim;
+
+    @Before
+    public void setUp() throws Exception {
+        claim = new BaseClaim();
+    }
+
+    @Test
+    public void shouldGetAsBoolean() throws Exception {
+        assertThat(claim.asBoolean(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsInt() throws Exception {
+        assertThat(claim.asInt(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsDouble() throws Exception {
+        assertThat(claim.asDouble(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsString() throws Exception {
+        assertThat(claim.asString(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsDate() throws Exception {
+        assertThat(claim.asDate(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsArray() throws Exception {
+        assertThat(claim.asArray(Object.class), is(notNullValue()));
+        assertThat(claim.asArray(Object.class), is(emptyArray()));
+    }
+
+    @Test
+    public void shouldGetAsList() throws Exception {
+        assertThat(claim.asList(Object.class), is(notNullValue()));
+        assertThat(claim.asList(Object.class), is(empty()));
+    }
+
+}

--- a/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
@@ -2,7 +2,6 @@ package com.auth0.android.jwt;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonSyntaxException;
 
 import org.hamcrest.collection.IsArrayWithSize;
 import org.hamcrest.collection.IsEmptyCollection;
@@ -27,7 +26,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 23)
-public class ClaimTest {
+public class ClaimImplTest {
 
     Gson gson;
     @Rule
@@ -42,7 +41,7 @@ public class ClaimTest {
     @Test
     public void shouldGetBooleanValue() throws Exception {
         JsonElement value = gson.toJsonTree(true);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asBoolean(), is(notNullValue()));
         assertThat(claim.asBoolean(), is(true));
@@ -51,7 +50,7 @@ public class ClaimTest {
     @Test
     public void shouldGetNullBooleanIfNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asBoolean(), is(nullValue()));
     }
@@ -59,7 +58,7 @@ public class ClaimTest {
     @Test
     public void shouldGetIntValue() throws Exception {
         JsonElement value = gson.toJsonTree(123);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asInt(), is(notNullValue()));
         assertThat(claim.asInt(), is(123));
@@ -68,7 +67,7 @@ public class ClaimTest {
     @Test
     public void shouldGetNullIntIfNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asInt(), is(nullValue()));
     }
@@ -76,7 +75,7 @@ public class ClaimTest {
     @Test
     public void shouldGetDoubleValue() throws Exception {
         JsonElement value = gson.toJsonTree(1.5);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asDouble(), is(notNullValue()));
         assertThat(claim.asDouble(), is(1.5));
@@ -85,7 +84,7 @@ public class ClaimTest {
     @Test
     public void shouldGetNullDoubleIfNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asDouble(), is(nullValue()));
     }
@@ -93,7 +92,7 @@ public class ClaimTest {
     @Test
     public void shouldGetDateValue() throws Exception {
         JsonElement value = gson.toJsonTree("1476824844");
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asDate(), is(notNullValue()));
         assertThat(claim.asDate(), is(new Date(1476824844L * 1000)));
@@ -102,7 +101,7 @@ public class ClaimTest {
     @Test
     public void shouldGetNullDateIfNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asDate(), is(nullValue()));
     }
@@ -110,7 +109,7 @@ public class ClaimTest {
     @Test
     public void shouldGetStringValue() throws Exception {
         JsonElement value = gson.toJsonTree("string");
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asString(), is(notNullValue()));
         assertThat(claim.asString(), is("string"));
@@ -119,7 +118,7 @@ public class ClaimTest {
     @Test
     public void shouldGetNullStringIfNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asString(), is(nullValue()));
     }
@@ -127,7 +126,7 @@ public class ClaimTest {
     @Test
     public void shouldGetArrayValueOfCustomClass() throws Exception {
         JsonElement value = gson.toJsonTree(new UserPojo[]{new UserPojo("George", 1), new UserPojo("Mark", 2)});
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asArray(UserPojo.class), is(notNullValue()));
         assertThat(claim.asArray(UserPojo.class), is(arrayContaining(new UserPojo("George", 1), new UserPojo("Mark", 2))));
@@ -136,7 +135,7 @@ public class ClaimTest {
     @Test
     public void shouldGetArrayValue() throws Exception {
         JsonElement value = gson.toJsonTree(new String[]{"string1", "string2"});
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asArray(String.class), is(notNullValue()));
         assertThat(claim.asArray(String.class), is(arrayContaining("string1", "string2")));
@@ -145,7 +144,7 @@ public class ClaimTest {
     @Test
     public void shouldGetEmptyArrayIfNullValue() throws Exception {
         JsonElement value = gson.toJsonTree(null);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asArray(String.class), is(notNullValue()));
         assertThat(claim.asArray(String.class), is(IsArrayWithSize.<String>emptyArray()));
@@ -154,7 +153,7 @@ public class ClaimTest {
     @Test
     public void shouldGetEmptyArrayIfNonArrayValue() throws Exception {
         JsonElement value = gson.toJsonTree(1);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asArray(String.class), is(notNullValue()));
         assertThat(claim.asArray(String.class), is(IsArrayWithSize.<String>emptyArray()));
@@ -163,7 +162,7 @@ public class ClaimTest {
     @Test
     public void shouldThrowIfArrayClassMismatch() throws Exception {
         JsonElement value = gson.toJsonTree(new String[]{"keys", "values"});
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         exception.expect(DecodeException.class);
         claim.asArray(UserPojo.class);
@@ -172,7 +171,7 @@ public class ClaimTest {
     @Test
     public void shouldGetListValueOfCustomClass() throws Exception {
         JsonElement value = gson.toJsonTree(Arrays.asList(new UserPojo("George", 1), new UserPojo("Mark", 2)));
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asList(UserPojo.class), is(notNullValue()));
         assertThat(claim.asList(UserPojo.class), is(hasItems(new UserPojo("George", 1), new UserPojo("Mark", 2))));
@@ -181,7 +180,7 @@ public class ClaimTest {
     @Test
     public void shouldGetListValue() throws Exception {
         JsonElement value = gson.toJsonTree(Arrays.asList("string1", "string2"));
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asList(String.class), is(notNullValue()));
         assertThat(claim.asList(String.class), is(hasItems("string1", "string2")));
@@ -190,7 +189,7 @@ public class ClaimTest {
     @Test
     public void shouldGetEmptyListIfNullValue() throws Exception {
         JsonElement value = gson.toJsonTree(null);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asList(String.class), is(notNullValue()));
         assertThat(claim.asList(String.class), is(IsEmptyCollection.emptyCollectionOf(String.class)));
@@ -199,7 +198,7 @@ public class ClaimTest {
     @Test
     public void shouldGetEmptyListIfNonArrayValue() throws Exception {
         JsonElement value = gson.toJsonTree(1);
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         assertThat(claim.asList(String.class), is(notNullValue()));
         assertThat(claim.asList(String.class), is(IsEmptyCollection.emptyCollectionOf(String.class)));
@@ -208,7 +207,7 @@ public class ClaimTest {
     @Test
     public void shouldThrowIfListClassMismatch() throws Exception {
         JsonElement value = gson.toJsonTree(new String[]{"keys", "values"});
-        Claim claim = new Claim(value);
+        ClaimImpl claim = new ClaimImpl(value);
 
         exception.expect(DecodeException.class);
         claim.asList(UserPojo.class);

--- a/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
@@ -298,10 +298,12 @@ public class JWTTest {
     //Private Claims
 
     @Test
-    public void shouldGetNullIfClaimIsMissing() throws Exception {
+    public void shouldGetBaseClaimIfClaimIsMissing() throws Exception {
         JWT jwt = new JWT("eyJhbGciOiJIUzI1NiJ9.e30.K17vlwhE8FCMShdl1_65jEYqsQqBOVMPUU9IgG-QlTM");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getClaim("notExisting"), is(nullValue()));
+        assertThat(jwt.getClaim("notExisting"), is(notNullValue()));
+        assertThat(jwt.getClaim("notExisting"), is(not(instanceOf(ClaimImpl.class))));
+        assertThat(jwt.getClaim("notExisting"), is(instanceOf(BaseClaim.class)));
     }
 
     @Test
@@ -309,7 +311,7 @@ public class JWTTest {
         JWT jwt = new JWT("eyJhbGciOiJIUzI1NiJ9.eyJvYmplY3QiOnsibmFtZSI6ImpvaG4ifX0.lrU1gZlOdlmTTeZwq0VI-pZx2iV46UWYd5-lCjy6-c4");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getClaim("object"), is(notNullValue()));
-        assertThat(jwt.getClaim("object"), is(instanceOf(Claim.class)));
+        assertThat(jwt.getClaim("object"), is(instanceOf(ClaimImpl.class)));
     }
 
     //Parcelable


### PR DESCRIPTION
When asking a JWT for a specific Claim and it's not found, don't return null. Instead, return a `BaseClaim` which will have all the methods return null, excepto for those related to collections, which will return an empty collection.

Previous implementation:
```java
JWT jwt = new JWT("my.jwt.token");
Claim claim = jwt.getClaim("notExistingClaim");
String value = claim.asString(); // NPE is thrown
```

Now: 
```java
JWT jwt = new JWT("my.jwt.token");
Claim claim = jwt.getClaim("notExistingClaim");
String value = claim.asString(); // value == null
```