### PR TITLE
Throw JWTDecodeException when a claim can't be converted to a class

### DIFF
--- a/lib/src/main/java/com/auth0/android/jwt/Claim.java
+++ b/lib/src/main/java/com/auth0/android/jwt/Claim.java
@@ -16,6 +16,7 @@ public interface Claim {
      * If the value isn't of type Boolean or it can't be converted to a Boolean, null will be returned.
      *
      * @return the value as a Boolean or null.
+     * @throws DecodeException if the value can't be converted to a Boolean.
      */
     @Nullable
     Boolean asBoolean();
@@ -25,6 +26,7 @@ public interface Claim {
      * If the value isn't of type Integer or it can't be converted to an Integer, null will be returned.
      *
      * @return the value as an Integer or null.
+     * @throws DecodeException if the value can't be converted to an Int.
      */
     @Nullable
     Integer asInt();
@@ -34,6 +36,7 @@ public interface Claim {
      * If the value isn't of type Double or it can't be converted to a Double, null will be returned.
      *
      * @return the value as a Double or null.
+     * @throws DecodeException if the value can't be converted to a Double.
      */
     @Nullable
     Double asDouble();
@@ -43,6 +46,7 @@ public interface Claim {
      * If the value isn't of type String or it can't be converted to a String, null will be returned.
      *
      * @return the value as a String or null.
+     * @throws DecodeException if the value can't be converted to a String.
      */
     @Nullable
     String asString();
@@ -52,6 +56,7 @@ public interface Claim {
      * If the value can't be converted to a Date, null will be returned.
      *
      * @return the value as a Date or null.
+     * @throws DecodeException if the value can't be converted to a Date.
      */
     @Nullable
     Date asDate();

--- a/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
@@ -28,7 +28,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 @Config(constants = BuildConfig.class, sdk = 23)
 public class ClaimImplTest {
 
-    Gson gson;
+    private Gson gson;
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -48,7 +48,7 @@ public class ClaimImplTest {
     }
 
     @Test
-    public void shouldGetNullBooleanIfNotPrimitiveValue() throws Exception {
+    public void shouldReturnNullIfBooleanNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
         ClaimImpl claim = new ClaimImpl(value);
 
@@ -65,7 +65,7 @@ public class ClaimImplTest {
     }
 
     @Test
-    public void shouldGetNullIntIfNotPrimitiveValue() throws Exception {
+    public void shouldReturnIfIntNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
         ClaimImpl claim = new ClaimImpl(value);
 
@@ -82,10 +82,9 @@ public class ClaimImplTest {
     }
 
     @Test
-    public void shouldGetNullDoubleIfNotPrimitiveValue() throws Exception {
+    public void shouldReturnNullIfDoubleNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
         ClaimImpl claim = new ClaimImpl(value);
-
         assertThat(claim.asDouble(), is(nullValue()));
     }
 
@@ -99,10 +98,9 @@ public class ClaimImplTest {
     }
 
     @Test
-    public void shouldGetNullDateIfNotPrimitiveValue() throws Exception {
+    public void shouldReturnNullIfDateNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
         ClaimImpl claim = new ClaimImpl(value);
-
         assertThat(claim.asDate(), is(nullValue()));
     }
 
@@ -116,10 +114,9 @@ public class ClaimImplTest {
     }
 
     @Test
-    public void shouldGetNullStringIfNotPrimitiveValue() throws Exception {
+    public void shouldNullIfStringNotPrimitiveValue() throws Exception {
         JsonElement value = gson.toJsonTree(new Object());
         ClaimImpl claim = new ClaimImpl(value);
-
         assertThat(claim.asString(), is(nullValue()));
     }
 


### PR DESCRIPTION
Wrap ClassCastException/IllegalStateException thrown by Gson when calling i.e. `claim.asInt()` on a claim that can't be converted to that class.