### PR TITLE
Add tests for dates with large values deserializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 

--- a/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/ClaimImplTest.java
@@ -90,6 +90,18 @@ public class ClaimImplTest {
     }
 
     @Test
+    public void shouldGetLargeDateValue() throws Exception {
+        long seconds = Integer.MAX_VALUE + 10000L;
+        JsonElement value = gson.toJsonTree(seconds);
+        ClaimImpl claim = new ClaimImpl(value);
+
+        Date date = claim.asDate();
+        assertThat(date, is(notNullValue()));
+        assertThat(date.getTime(), is(seconds * 1000));
+        assertThat(date.getTime(), is(2147493647L * 1000));
+    }
+
+    @Test
     public void shouldGetDateValue() throws Exception {
         JsonElement value = gson.toJsonTree("1476824844");
         ClaimImpl claim = new ClaimImpl(value);

--- a/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
@@ -151,6 +151,19 @@ public class JWTTest {
     }
 
     @Test
+    public void shouldDeserializeDatesUsingLong() throws Exception {
+        JWT jwt = new JWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjIxNDc0OTM2NDcsIm5iZiI6MjE0NzQ5MzY0NywiZXhwIjoyMTQ3NDkzNjQ3LCJjdG0iOjIxNDc0OTM2NDd9.txmUJ0UCy2pqTFrEgj49eNDQCWUSW_XRMjMaRqcrgLg");
+        assertThat(jwt, is(notNullValue()));
+
+        long secs = Integer.MAX_VALUE + 10000L;
+        Date expectedDate = new Date(secs * 1000);
+        assertThat(jwt.getIssuedAt(), is(expectedDate));
+        assertThat(jwt.getNotBefore(), is(expectedDate));
+        assertThat(jwt.getExpiresAt(), is(expectedDate));
+        assertThat(jwt.getClaim("ctm").asDate(), is(expectedDate));
+    }
+
+    @Test
     public void shouldGetExpirationTime() throws Exception {
         JWT jwt = new JWT("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxNDc2NzI3MDg2In0.XwZztHlQwnAgmnQvrcWXJloLOUaLZGiY0HOXJCKRaks");
         assertThat(jwt, is(notNullValue()));


### PR DESCRIPTION
There's no `Numeric Overflow` issue when parsing dates as they are considered of type `long` in this library. This PR adds some tests to validate that. 