### PR TITLE
Change getClaim annotation to nonNull

### DIFF
--- a/lib/src/main/java/com/auth0/android/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/android/jwt/JWT.java
@@ -137,7 +137,7 @@ public class JWT implements Parcelable {
      * @param name the name of the Claim to retrieve.
      * @return a valid Claim.
      */
-    @Nullable
+    @NonNull
     public Claim getClaim(@NonNull String name) {
         return payload.claimForName(name);
     }


### PR DESCRIPTION
getClaim was annotated as nullable when the return value was always a valid claim.