### PR TITLE
remove unused `libs` dependency

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -39,7 +39,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Just removed the `libs` dependency (not used anyway) from `build.gradle`.