### PR TITLE
Migrate to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Oct 26 18:49:38 MDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,10 +23,10 @@ oss {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -41,9 +41,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testImplementation 'org.robolectric:robolectric:3.4.2'
-    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation 'org.robolectric:robolectric:3.4.2'

--- a/lib/src/main/java/com/auth0/android/jwt/BaseClaim.java
+++ b/lib/src/main/java/com/auth0/android/jwt/BaseClaim.java
@@ -1,7 +1,7 @@
 package com.auth0.android.jwt;
 
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.lang.reflect.Array;
 import java.util.Collections;

--- a/lib/src/main/java/com/auth0/android/jwt/Claim.java
+++ b/lib/src/main/java/com/auth0/android/jwt/Claim.java
@@ -1,6 +1,6 @@
 package com.auth0.android.jwt;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.Date;
 import java.util.List;

--- a/lib/src/main/java/com/auth0/android/jwt/ClaimImpl.java
+++ b/lib/src/main/java/com/auth0/android/jwt/ClaimImpl.java
@@ -1,7 +1,7 @@
 package com.auth0.android.jwt;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;

--- a/lib/src/main/java/com/auth0/android/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/android/jwt/JWT.java
@@ -2,8 +2,8 @@ package com.auth0.android.jwt;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Base64;
 
 import com.google.gson.Gson;

--- a/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/android/jwt/JWTTest.java
@@ -2,7 +2,7 @@ package com.auth0.android.jwt;
 
 import android.os.Bundle;
 import android.os.Parcel;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Base64;
 
 import org.hamcrest.collection.IsEmptyCollection;


### PR DESCRIPTION
### Changes

Migrate the project to AndroidX.
- Allows Android projects to not need to use the Jetifier step; needed when libraries are still using the old Support Libraries.
- No changes to API or functionality

### References

Inspired by this [issue](https://github.com/ZacSweers/CatchUp/issues/197).

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[ ] This change adds test coverage

[X] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[X] All existing and new tests complete without errors

```sh
➜  JWTDecode.Android git:(feature/androidx) ./gradlew clean test                                                                                                                                                                                                                                                                            

BUILD SUCCESSFUL in 21s
28 actionable tasks: 27 executed, 1 up-to-date
```