### PR TITLE
Bump GSON dependency to 2.8.9

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
This change bumps [the GSON dependency to 2.8.9](https://github.com/google/gson/releases/tag/gson-parent-2.8.9) to resolve a potential vulnerability in earlier versions of the library reported: https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327