### PR TITLE
Update Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,22 +9,22 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
       _JAVA_OPTIONS: -Xms512m -Xmx1024m
     docker:
-      - image: circleci/android:api-28
+      - image: cimg/android:2022.06
 
     steps:
-    - checkout
+      - checkout
 
-    - restore_cache:
-        keys:
-        - v1-dep-{{ .Branch }}-
+      - restore_cache:
+          keys:
+            - v1-dep-{{ .Branch }}-
 
-    - run: ./gradlew clean test jacocoTestReport --console=plain
+      - run: ./gradlew clean test jacocoTestReport --console=plain
 
-    - save_cache:
-            key: v1-dep-{{ .Branch }}-{{ epoch }}
-            paths:
+      - save_cache:
+          key: v1-dep-{{ .Branch }}-{{ epoch }}
+          paths:
             - ~/.gradle
             - ~/.android
             - /usr/local/android-sdk-linux/extras
 
-    - codecov/upload
+      - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@3
+
 jobs:
   build:
     environment:
@@ -23,7 +27,4 @@ jobs:
             - ~/.android
             - /usr/local/android-sdk-linux/extras
 
-    - run:
-          name: Upload Coverage
-          when: on_success
-          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+    - codecov/upload


### PR DESCRIPTION
This PR:

- Replaces the deprecated bash uploader for Codecov in our CircleCI workflow with the supported/recommended CircleCI Orb approach.
- Replaces the deprecated legacy CircleCI image with a supported one.