### PR TITLE
Release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.0.2](https://github.com/auth0/jwtdecode.android/tree/2.0.2) (2023-01-11)
+[Full Changelog](https://github.com/auth0/jwtdecode.android/compare/2.0.1...2.0.2)
+
+This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
+Please review [the README note for additional details.](https://github.com/auth0/JWTDecode.Android/blob/master/README.md)
+
 ## [2.0.1](https://github.com/auth0/jwtdecode.android/tree/2.0.1) (2021-11-08)
 [Full Changelog](https://github.com/auth0/jwtdecode.android/compare/2.0.0...2.0.1)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Note**
+> As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
+>
+> While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
+
 ![JWTDecode.Android](https://cdn.auth0.com/website/sdks/banners/jwtdecode-android-banner.png)
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/JWTDecode.Android.svg?style=flat-square)](https://circleci.com/gh/auth0/JWTDecode.Android/tree/master)
@@ -19,7 +24,7 @@
 The library is be available both in Maven Central and JCenter. To start using it add this line to your `build.gradle` dependencies file:
 
 ```groovy
-implementation 'com.auth0.android:jwtdecode:2.0.1'
+implementation 'com.auth0.android:jwtdecode:2.0.2'
 ```
 
 ### Usage


### PR DESCRIPTION
## [2.0.2](https://github.com/auth0/jwtdecode.android/tree/2.0.2) (2023-01-11)
[Full Changelog](https://github.com/auth0/jwtdecode.android/compare/2.0.1...2.0.2)

This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
Please review [the README note for additional details.](https://github.com/auth0/JWTDecode.Android/blob/master/README.md)