### PR TITLE
Fix/spdx license url

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -8,5 +8,5 @@ jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
-      java-version: "8"
+      java-version: "11"
     secrets: inherit

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -50,3 +50,14 @@ tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
     jacoco.excludes = ['jdk.internal.*']
 }
+
+afterEvaluate {
+    publishing.publications.all {
+        pom.withXml {
+            def licenseNode = asNode().getAt('licenses')[0]?.getAt('license')[0]
+            if (licenseNode) {
+                licenseNode.getAt('url')[0].setValue('https://spdx.org/licenses/MIT.html')
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Changes

- Overrides the license URL in the published Maven POM from a raw GitHub link to the standard SPDX URL (https://spdx.org/licenses/MIT.html) via an afterEvaluate block in lib/build.gradle.
- The upstream plugin (com.auth0.gradle.oss-library.android) is archived and cannot be patched directly.
- No code, API, or license terms changed — metadata only.
- Alternative considered: forking the plugin — rejected as overkill.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Run ./gradlew :jwtdecode:generatePomFileForReleasePublication
Verify generated POM contains <url>https://spdx.org/licenses/MIT.html</url>
Run ./gradlew build — no regressions.


### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
