### PR TITLE
fix(ci): prevent workflow script injection via env vars

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,11 +24,14 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java }}
 
-    - run: |
+    - env:
+        GRADLE: ${{ inputs.gradle }}
+        KOTLIN: ${{ inputs.kotlin }}
+      run: |
         curl -s "https://get.sdkman.io" | bash
         source "$HOME/.sdkman/bin/sdkman-init.sh"
-        sdk install gradle ${{ inputs.gradle }} && sdk default gradle ${{ inputs.gradle }}
-        sdk install kotlin ${{ inputs.kotlin }} && sdk default kotlin ${{ inputs.kotlin }}
+        sdk install gradle "$GRADLE" && sdk default gradle "$GRADLE"
+        sdk install kotlin "$KOTLIN" && sdk default kotlin "$KOTLIN"
       shell: bash
 
     - run: ./gradlew androidDependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,9 @@ jobs:
 
       - run: ./gradlew exportVersion -PisSnapshot=false
 
-      - run: ./gradlew publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="${{ secrets.OSSR_USERNAME }}" -PossrhPassword="${{ secrets.OSSR_PASSWORD }}" -PsigningKey="${{ secrets.SIGNING_KEY }}" -PsigningPassword="${{ secrets.SIGNING_PASSWORD }}" -PisSnapshot=false"
+      - env:
+          OSSR_USERNAME: ${{ secrets.OSSR_USERNAME }}
+          OSSR_PASSWORD: ${{ secrets.OSSR_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="$OSSR_USERNAME" -PossrhPassword="$OSSR_PASSWORD" -PsigningKey="$SIGNING_KEY" -PsigningPassword="$SIGNING_PASSWORD" -PisSnapshot=false


### PR DESCRIPTION
### Changes

This PR remediates a **GitHub Workflow script injection** vulnerability in the CI/publish workflows. Untrusted `${{ }}` expressions (action inputs and secrets) were being interpolated directly into shell `run:` scripts, allowing anyone able to invoke the workflow to inject arbitrary shell commands and potentially exfiltrate secrets. Per [GitHub's secure-use guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections), the fix moves these values into `env:` blocks and references them as quoted shell variables so the shell treats them as data, not code.

- **`.github/actions/setup/action.yml`** — `inputs.gradle` / `inputs.kotlin` moved to an `env:` block (`$GRADLE` / `$KOTLIN`) and referenced as quoted shell variables in the sdkman `run:` step.
- **`.github/workflows/publish.yml`** — the `OSSR_USERNAME`, `OSSR_PASSWORD`, `SIGNING_KEY`, and `SIGNING_PASSWORD` secrets moved to an `env:` block on the `publishAndroidLibraryPublicationToMavenRepository` step; also removed a stray trailing `"` after `-PisSnapshot=false`.

No endpoints, classes, methods, public APIs, or UI are affected — the change is confined to CI workflow configuration.

**Not changed (verified safe):** `inputs.java` (`with:` field of `setup-java`), `github.event.inputs.branch` (`ref:` of `checkout`), and the concurrency `group:` expressions are consumed by the Actions runner, not a shell, so they are not injection vectors.

**Alternatives considered:** Restricting inputs via `choice`-type parameters was considered but rejected — the env-var pattern is GitHub's recommended mitigation, is minimally invasive, and preserves the existing flexibility of the composite action's version inputs.

### References

SEC-8159

### Testing

- **YAML syntax** validated for both files (`yaml.safe_load` — both parse cleanly).
- **actionlint** (recommended for reviewers): `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color`
- **Injection closed (behavioral check):** a malicious version string (e.g. `GRADLE='6.7.1; touch pwned'`) is now treated as a literal argument to `sdk` rather than executed as a command.
- **Publish workflow** cannot be end-to-end tested from a PR since it requires the `release` environment and real Maven Central credentials; the change is limited to how existing secrets are passed and does not alter the gradle command's behavior.

[ ] This change adds test coverage — N/A (workflow configuration; no unit-testable surface)

[x] This change has been tested on the latest version of the platform/language or why not — validated via YAML parsing and injection simulation; live publish run not exercised (requires protected `release` environment + credentials).

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
