### PR TITLE
fix(ci): use workflow_call hyphen secret names in java-release

### DIFF
--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -65,10 +65,10 @@ jobs:
       - uses: ./.github/actions/maven-publish
         with:
           java-version: ${{ inputs.java-version }}
-          ossr-username: ${{ secrets.OSSR_USERNAME }}
-          ossr-token: ${{ secrets.OSSR_TOKEN }}
-          signing-key: ${{ secrets.SIGNING_KEY }}
-          signing-password: ${{ secrets.SIGNING_PASSWORD }}
+          ossr-username: ${{ secrets.ossr-username }}
+          ossr-token: ${{ secrets.ossr-token }}
+          signing-key: ${{ secrets.signing-key }}
+          signing-password: ${{ secrets.signing-password }}
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create


### PR DESCRIPTION
### Changes

Fixes the reusable release workflow so `maven-publish` reads the correct secret names.

`.github/workflows/java-release.yml` referenced `secrets.OSSR_USERNAME`, `secrets.SIGNING_KEY`, etc., but inside a `workflow_call` workflow only the hyphenated names declared in its `secrets:` block are in scope. The uppercase refs resolved to empty, so `SIGNING_KEY`/`MAVEN_*` reached Gradle blank and the `2.0.3` release failed at the `signing {}` block (nothing published, no tag created). Changed them to `secrets.ossr-username`, `secrets.signing-key`, etc., matching `auth0/Auth0.Android`.

CI/release wiring only — no library, API, or UI changes.


### Testing

- Static: the `secrets.*` refs now match the `workflow_call: secrets:` declarations in the same file.
- Post-merge: re-run the release workflow and confirm `publishToSonatype`/`closeSonatypeStagingRepository` succeed with a staged `com.auth0.android:jwtdecode:2.0.3` in the Central Portal.
- No unit tests apply (workflow-only change); existing `Build and Test` CI runs unaffected.

[x] This change adds test coverage

[x] This change has been tested on the latest version of the platform/language or why not

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
