### PR TITLE
fix(ci): pin sonatype stagingProfileId to com.auth0 namespace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'io.github.gradle-nexus.publish-plugin'
 nexusPublishing {
     repositories {
         sonatype {
+            stagingProfileId.set(MAVEN_GROUP_ID)
             nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
             username.set(System.getenv("MAVEN_USERNAME"))
             password.set(System.getenv("MAVEN_PASSWORD"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@ android.useAndroidX=true
 
 # Maven publishing / POM metadata
 GROUP=com.auth0.android
+# Sonatype staging profile namespace (parent profile covering all com.auth0.* artifacts)
+MAVEN_GROUP_ID=com.auth0
 POM_ARTIFACT_ID=jwtdecode
 
 POM_NAME=JWTDecode.Android


### PR DESCRIPTION
### Changes

Pins the Sonatype `stagingProfileId` to the parent `com.auth0` namespace so releases can publish.

- **`build.gradle`** — added `stagingProfileId.set(MAVEN_GROUP_ID)` to the `nexusPublishing.sonatype` block.
- **`gradle.properties`** — added `MAVEN_GROUP_ID=com.auth0`.

**Why:** The nexus-publish plugin auto-resolves the staging profile by an *exact* match on the project group (`com.auth0.android`), which has no profile of its own. This caused releases to fail with `Failed to find staging profile for package group: com.auth0.android`. The real profile is the parent `com.auth0` namespace, which covers all `com.auth0.*` artifacts.

**Alternative considered:** hardcoding the literal `'com.auth0'` in `build.gradle`. Chose the `MAVEN_GROUP_ID` property instead to match `ui-components-android` and keep the value alongside `GROUP`.

No API, endpoint, or UI changes — build/release config only.

### Testing

Build/release config change only — no unit or integration tests apply.

- Verified the `com.auth0` staging profile exists and covers `com.auth0.android` via the Sonatype staging API (`/staging/profile_evaluate?g=com.auth0.android` resolves to the `com.auth0` profile).
- End-to-end verification is the release workflow itself: on merge, `release.yml` runs `publishToSonatype closeSonatypeStagingRepository`, which previously failed at `initializeSonatypeStagingRepository` with `Failed to find staging profile for package group: com.auth0.android` and should now succeed.

**Not tested locally:** the full publish requires the `release` environment secrets (Sonatype token + signing key), so it can only be exercised by the CI release run.

[x] This change adds test coverage

[x] This change has been tested on the latest version of the platform/language or why not

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
