### PR TITLE
chore(security): pinning GH actions to hashes

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pin@v7.1.0
       id: get_release_notes
       with:
         result-encoding: string

--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -18,7 +18,7 @@ runs:
 
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
 
     - name: Set up Java
       uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # pin@v4

--- a/.github/actions/release-create/action.yml
+++ b/.github/actions/release-create/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
 
   steps:
-    - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+    - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
       with:
         body: ${{ inputs.body }}
         name: ${{ inputs.name }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # pin@v4.9.1
       with:
         distribution: temurin
         java-version: ${{ inputs.java }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,18 +36,18 @@ jobs:
         run: exit 0 # Skip unnecessary test runs for dependabot and merge queues. Artifically flag as successful, as this is a required check for branch protection.
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.5
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # pin@v4.37.5
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.5
+        uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43 # pin@v4.37.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.5
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # pin@v4.37.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
### Changes

This pull request updates the GitHub Actions workflow files to use pinned commit SHAs for all third-party actions, improving security and reproducibility.

