### PR TITLE
chore : grouped the dependabot updates for codeql and java setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'
+      setup-java:
+        patterns:
+          - 'actions/setup-java*'


### PR DESCRIPTION
### Changes

This PR groups the dependabot update on codeql to a single PR instead of 3 separate PRs